### PR TITLE
chore: JSDoc, .d.ts, persistent storage builtin driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.10",
   "description": "A fast key value database",
   "main": "src/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test": "node test.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,28 @@ You can rebuild the database by calling the reconstruct method on the SOC manage
 db.SOCManager.reconstruct()
 ```
 
+## Persistent
+The Persistent driver stores database content into a key/value file periodically, to recover from shutdowns
+with a concise representation of the database.
+
+### Initialization
+You first need to import the Persistent driver and initialize it. You need to give if a path to save to:
+
+```js
+const { PersistentDriver } = require("keychaindb");
+const path = require("path");
+
+db.use(PersistentDriver, { path: path.join(__dirname, "persistent.db") });
+```
+
+### Rebuilding
+You can rebuild the database instance from the content stored on the disk by calling:
+```js
+db.fromStorage();
+```
+
+The operation is synchronous.
+
 # License
 KeychainDB is licensed under the ISC License. See the LICENSE file for more details.
 

--- a/src/driver/persistent.js
+++ b/src/driver/persistent.js
@@ -1,3 +1,9 @@
+/**
+ * @author Johan Delhomme Montorfano <me@johanmontorfano.com>
+ * @description PersistentDriver file definition to allow for non-cache based
+ * storage.
+**/ 
+
 const { openSync, writeFileSync, readFileSync } = require("node:fs");
 
 /**

--- a/src/driver/persistent.js
+++ b/src/driver/persistent.js
@@ -62,7 +62,7 @@ function readDatabase(db) {
  * @param {string} config.path - Path of the file to save data to.
  * 
  * Adds the following public properties to db:
- * @property {Function} reconstruct - Reset the database with file content.
+ * @property {Function} fromStorage - Reset the database with file content.
 **/
 function PersistentDriver(db, config) {
     if (!config.path)
@@ -70,7 +70,7 @@ function PersistentDriver(db, config) {
     db._persistentPath = config.path;
     db._persistentFile = createPath(config.path);
     db._changes = 0;
-    db.reconstruct = () => readDatabase(db);
+    db.fromStorage = () => readDatabase(db);
     db.on("set", () => db._changes++);
     db.on("delete", () => db._changes++);
     setInterval(() => {

--- a/src/driver/persistent.js
+++ b/src/driver/persistent.js
@@ -47,8 +47,8 @@ function readDatabase(db) {
 }
 
 /**
- *  `persistent` is a driver for the `Database` class used to periodically
- *  save read content to a text file.
+ *  Driver for the `Database` class used to periodically
+ *  save content to a text file.
  *
  *  Usage:
  *  ```js

--- a/src/driver/persistent.js
+++ b/src/driver/persistent.js
@@ -13,7 +13,7 @@ const { openSync, writeFileSync, readFileSync } = require("node:fs");
 **/
 function createPath(path) {
     try {
-        return openSync(path, "r+");
+        return openSync(path, "w+");
     } catch ({message: msg}) {
         throw new Error(`PersistentDriver: filesystem error! ${msg}`);
     }
@@ -25,14 +25,15 @@ function createPath(path) {
  * @param {Database} db
 **/
 function writeDatabase(db) {
-    const outContent = "";
+    let outContent = "";
 
-    db.entries().forEach(([key, value]) => {
+    db.entries().forEach(([key, {value}]) => {
         if (typeof key === "string" && key.indexOf("\t") > -1)
             throw new Error("PersistentDriver: Found tabs in a key");
-        outContent += `${JSON.stringify(key)}\t${JSON.stringify(value)}`;
+        outContent += `${JSON.stringify(key)}\t${JSON.stringify(value)}\n`;
     });
-    writeFileSync(db._persistentFile, outContent);
+    console.log("$", outContent, "$");
+    writeFileSync(db._persistentPath, outContent, {flag: "w"});
 }
 
 /**
@@ -74,7 +75,6 @@ function PersistentDriver(db, config) {
     if (!config.path)
         throw new Error("PersistentDriver: Missing database path");
     db._persistentPath = config.path;
-    db._persistentFile = createPath(config.path);
     db._changes = 0;
     db.fromStorage = () => readDatabase(db);
     db.on("set", () => db._changes++);

--- a/src/driver/persistent.js
+++ b/src/driver/persistent.js
@@ -1,0 +1,84 @@
+const { openSync, writeFileSync, readFileSync } = require("node:fs");
+
+/**
+ * Open/Create a file.
+ * 
+ * @param {string} path
+**/
+function createPath(path) {
+    try {
+        return openSync(path, "r+");
+    } catch ({message: msg}) {
+        throw new Error(`PersistentDriver: filesystem error! ${msg}`);
+    }
+}
+
+/**
+ * Write the database to a text file.
+ *
+ * @param {Database} db
+**/
+function writeDatabase(db) {
+    const outContent = "";
+
+    db.entries().forEach(([key, value]) => {
+        if (typeof key === "string" && key.indexOf("\t") > -1)
+            throw new Error("PersistentDriver: Found tabs in a key");
+        outContent += `${JSON.stringify(key)}\t${JSON.stringify(value)}`;
+    });
+    writeFileSync(db._persistentFile, outContent);
+}
+
+/**
+ * Reads the database file to a database instance.
+ *
+ * @param {Database} db
+*/
+function readDatabase(db) {
+    const readContent = readFileSync(db._persistentFile);
+    const lines = readContent.split("\n");
+
+    db._changes = -lines.length;
+    lines.forEach(lines => {
+        const [key, value] = lines.split("\t");
+        db.set(JSON.parse(key), JSON.parse(value));
+    });
+    db._changes = 0;
+}
+
+/**
+ *  `persistent` is a driver for the `Database` class used to periodically
+ *  save read content to a text file.
+ *
+ *  Usage:
+ *  ```js
+ *  const db = new Database();
+ *
+ *  db.use(PersistentDriver, { path: <filename> });
+ *  ```
+ * 
+ * @param {Database} db - Database to operate on.
+ * @param {Object} config - Driver configuration.
+ * @param {string} config.path - Path of the file to save data to.
+ * 
+ * Adds the following public properties to db:
+ * @property {Function} reconstruct - Reset the database with file content.
+**/
+function PersistentDriver(db, config) {
+    if (!config.path)
+        throw new Error("PersistentDriver: Missing database path");
+    db._persistentPath = config.path;
+    db._persistentFile = createPath(config.path);
+    db._changes = 0;
+    db.reconstruct = () => readDatabase(db);
+    db.on("set", () => db._changes++);
+    db.on("delete", () => db._changes++);
+    setInterval(() => {
+        if (db._changes > 0) {
+            writeDatabase(db);
+            db._changes = 0;
+        }
+    }, 100);
+}
+
+module.exports = PersistentDriver;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,7 @@ export declare function SOCDriver(db: Database, config: {path: string}): void;
  * @param {string} config.path - Path of the file to save data to.
  * 
  * Adds the following public properties to db:
- * @property {Function} reconstruct - Reset the database with file content.
+ * @property {Function} fromStorage - Reset the database with file content.
 **/
 export declare function PersistentDriver(
     db: Database,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,55 @@
+/**
+ * @param {Object} entry - Entry that has been manipulated
+ * @param {string} entry.key
+ * @param {any} entry.value
+ * @param {number} entry.writedate
+ * @param {number} entry.expire
+**/ 
+export declare function ControllerCallback(entry: {
+    key: string,
+    value: any,
+    writedate: number,
+    expire: number
+}): void;
+
+/**
+ * Solid Operation Cache driver to use with `Database`
+ * ```js
+ * const db = new Database();
+ * 
+ * db.use(SOCDriver, {path: <filename>});
+ * ```
+ *
+ * @param {Database} db - Database to operate on
+ * @param {Object} config - Configuration of the driver
+ * @param {string} config.path - Cache storage file path
+**/
+export declare function SOCDriver(
+    db: Database,
+    config?: Partial<{path: string}>
+): void;
+
+/**
+ * @class
+ * Database instance.
+**/
+export declare class Database {
+    constructor(config: {});
+    on(eventName: string, callback: (...args: any) => void): void;
+    emit(eventName: string, ...args: any): void;
+    set(key: string, value: any, expire: number): void;
+    delete(key: string): void;
+    get(key: string): any;
+    find(query: any): any[];
+    has(key: string): boolean;
+    login(): void;
+    isExpired(key: string): boolean;
+    use(callback: (instance: Database, options: any) => void): void;
+    beforeSet(callback: ControllerCallback): void;
+    beforeGet(callback: ControllerCallback): void;
+    beforeDelete(callback: ControllerCallback): void;
+    beforeReady(callback: ControllerCallback): void;
+    keys(): any[];
+    values(): any[];
+    entries(): [any, any][];
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,16 +54,77 @@ export declare function PersistentDriver(
  * Database instance.
 **/
 export declare class Database {
-    constructor(config: {});
+    constructor();
+    /**
+     * Add a event listener for specific events.
+     * 
+     * @param {string} eventName - Event to subscribe to. Events sent by
+     * default are "ready, "set" and "delete".
+     * @param {Function} callback - Callback function that takes an infinite
+     * number of arguments.
+    **/
     on(eventName: string, callback: (...args: any) => void): void;
+    /**
+     * Emit an event to listeners.
+     *
+     * @param {string} eventName
+     * @param {...any} args - Arguments to submit to listeners.
+    **/
     emit(eventName: string, ...args: any): void;
+    /**
+     * Set a key/pair to the database.
+     *
+     * @param {any} key
+     * @param {any} value
+     * @param {number} expire - Cache expiration
+    **/
     set(key: any, value: any, expire: number): void;
+    /**
+     * Key/pair to delete from the database.
+     *
+     * @param {any] key
+    **/
     delete(key: any): void;
+    /**
+     * Retrieve the value of a key.
+     *
+     * @param {any} key
+     * @returns {any}
+    **/
     get(key: any): any;
-    find(query: any): any[];
+    /**
+     * Search for matching key/pair by values.
+     *
+     * @param {any} query
+     * @returns {Array<Object>} - List of results
+     * @returns {Array<Object>[i].key}
+     * @returns {Array<Object>[i].value}
+    **/
+    find(query: any): {key: any, value: any}[];
+    /**
+     * Determine if a key exist.
+     *
+     * @param {any} key
+     * @returns {boolean}
+    **/
     has(key: any): boolean;
+    /**
+     * Emit a "ready" event and mark the database as ready.
+    **/
     login(): void;
+    /**
+     * Determines if a key has expired in cache.
+     *
+     * @param {any} key
+     * @returns {boolean}
+    **/
     isExpired(key: any): boolean;
+    /**
+     * Implement a plugin/driver methods to the instance. Default drivers
+     * are `SOCDriver` and `PersistentDriver`.
+     *
+     * @param {Function} callback - Plugin/driver initializer
+    **/
     use(callback: (instance: Database, options: any) => void): void;
     beforeSet(callback: ControllerCallback): void;
     beforeGet(callback: ControllerCallback): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -91,7 +91,7 @@ export declare class Database {
     /**
      * Key/pair to delete from the database.
      *
-     * @param {any] key
+     * @param {any} key
     **/
     delete(key: any): void;
     /**
@@ -135,10 +135,10 @@ export declare class Database {
      * @param {Function} callback - Plugin/driver initializer
     **/
     use(callback: (instance: Database, options: any) => void, config: any): void;
-    beforeSet(callback: ControllerCallback): void;
-    beforeGet(callback: ControllerCallback): void;
-    beforeDelete(callback: ControllerCallback): void;
-    beforeReady(callback: ControllerCallback): void;
+    beforeSet(callback: typeof ControllerCallback): void;
+    beforeGet(callback: typeof ControllerCallback): void;
+    beforeDelete(callback: typeof ControllerCallback): void;
+    beforeReady(callback: typeof ControllerCallback): void;
     keys(): any[];
     values(): any[];
     entries(): [any, any][];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,9 @@
 /**
+ * @author Johan Delhomme Montorfano <me@johanmontorfano.com>
+ * @description Types and JSDoc descriptions.
+**/ 
+
+/**
  * @param {Object} entry - Entry that has been manipulated
  * @param {string} entry.key
  * @param {any} entry.value

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,13 +37,13 @@ export declare class Database {
     constructor(config: {});
     on(eventName: string, callback: (...args: any) => void): void;
     emit(eventName: string, ...args: any): void;
-    set(key: string, value: any, expire: number): void;
-    delete(key: string): void;
-    get(key: string): any;
+    set(key: any, value: any, expire: number): void;
+    delete(key: any): void;
+    get(key: any): any;
     find(query: any): any[];
-    has(key: string): boolean;
+    has(key: any): boolean;
     login(): void;
-    isExpired(key: string): boolean;
+    isExpired(key: any): boolean;
     use(callback: (instance: Database, options: any) => void): void;
     beforeSet(callback: ControllerCallback): void;
     beforeGet(callback: ControllerCallback): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -27,7 +27,7 @@ export declare function ControllerCallback(entry: {
 export declare function SOCDriver(db: Database, config: {path: string}): void;
 
 /**
- *  `persistent` is a driver for the `Database` class used to periodically
+ *  Driver for the `Database` class used to periodically
  *  save read content to a text file.
  *
  *  Usage:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,9 +24,29 @@ export declare function ControllerCallback(entry: {
  * @param {Object} config - Configuration of the driver
  * @param {string} config.path - Cache storage file path
 **/
-export declare function SOCDriver(
+export declare function SOCDriver(db: Database, config: {path: string}): void;
+
+/**
+ *  `persistent` is a driver for the `Database` class used to periodically
+ *  save read content to a text file.
+ *
+ *  Usage:
+ *  ```js
+ *  const db = new Database();
+ *
+ *  db.use(PersistentDriver, { path: <filename> });
+ *  ```
+ * 
+ * @param {Database} db - Database to operate on.
+ * @param {Object} config - Driver configuration.
+ * @param {string} config.path - Path of the file to save data to.
+ * 
+ * Adds the following public properties to db:
+ * @property {Function} reconstruct - Reset the database with file content.
+**/
+export declare function PersistentDriver(
     db: Database,
-    config?: Partial<{path: string}>
+    config: {path: string}
 ): void;
 
 /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -54,6 +54,10 @@ export declare function PersistentDriver(
     config: {path: string}
 ): void;
 
+export interface PersistentDriverExtends {
+    fromStorage(): void;
+}
+
 /**
  * @class
  * Database instance.
@@ -130,7 +134,7 @@ export declare class Database {
      *
      * @param {Function} callback - Plugin/driver initializer
     **/
-    use(callback: (instance: Database, options: any) => void): void;
+    use(callback: (instance: Database, options: any) => void, config: any): void;
     beforeSet(callback: ControllerCallback): void;
     beforeGet(callback: ControllerCallback): void;
     beforeDelete(callback: ControllerCallback): void;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const SOCDriver = require("./driver/soc")
+const PersistentDriver = require("./driver/persistent")
 
 class Database {
     constructor (config = {}) {
@@ -184,4 +185,4 @@ class Database {
     }
 }
 
-module.exports = {Database, SOCDriver}
+module.exports = {Database, SOCDriver, PersistentDriver}


### PR DESCRIPTION
- Added a comprehensive JSDoc to some `.js` files and all the declarations in the `.d.ts` file, allowing for easy onboarding for both JavaScript and TypeScript users.
- Added a built-in module called `PersistentDriver` to allow users to save the database state to a comprehensive file, without having to rely on the heavily cache-related `SOCDriver` when they want to just exit the app. It is a great complement to `SOCDriver`.

